### PR TITLE
chore: refactor code to use sync broadcast mode in cosmos txs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,12 @@
-FROM node:16 as builder
+FROM node:16
 
-WORKDIR /app/
+WORKDIR /app/bots
 
-COPY package.json package-lock.json ./
-COPY tsconfig.json tsconfig.json
+COPY . .
+
 RUN npm install
-
-COPY src/ ./src/
-
 RUN npm run build
 
-RUN /bin/bash -c find . ! -name dist ! -name node_modules -maxdepth 1 -mindepth 1 -exec rm -rf {} \\;
-
-
-FROM node:16-alpine
-
-WORKDIR /app/
-ENV NODE_ENV=production
-
-COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/node_modules ./node_modules
-COPY contracts contracts
-
-ENTRYPOINT ["node", "./dist/index.js"]
+ENTRYPOINT ["node" , "./dist/index.js"]
 
 EXPOSE 8080

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -60,7 +60,7 @@ export interface Contracts {
 export class Orchestrator {
   private readonly params: OrchestratorParams;
   private workers: IWorker[] = [];
-  private provider: providers.Provider;
+  private provider: providers.JsonRpcProvider;
   private readonly signer: NonceManager;
   private wallet: Wallet;
   private checkBalanceInterval?: NodeJS.Timer;
@@ -288,7 +288,7 @@ export class Orchestrator {
     }
 
     this.onFailedTx(err);
-    this.logger.error('error funding address ', address);
+    this.logger.error(`error funding address ${address}`);
     return false;
   }
 
@@ -376,6 +376,7 @@ export class Orchestrator {
     this.logger.info(`submitting proposal`);
     return sendCosmosTxWithNonceRefresher(
       ctx,
+      this.provider,
       proposal,
       createTxMsgSubmitProposal,
       this.wallet,
@@ -400,6 +401,7 @@ export class Orchestrator {
     this.logger.info(`voting proposal #${proposalId}`);
     await sendCosmosTxWithNonceRefresher(
       ctx,
+      this.provider,
       vote,
       createTxMsgVote,
       this.wallet,

--- a/src/worker/iworker.ts
+++ b/src/worker/iworker.ts
@@ -13,7 +13,7 @@ export interface Account {
 
 export interface IWorkerParams {
   account: Account;
-  provider: providers.Provider;
+  provider: providers.JsonRpcProvider;
   successfulTxCounter: Counter<string>;
   failedTxCounter: Counter<string>;
   successfulTxFeeGauge: Gauge<string>;


### PR DESCRIPTION
# Description

When upgrading to cosmos-sdk v0.47, the `block` broadcast mode is deprecated.

This PR introduces the changes to fix this by replacing the broadcast mode to `sync` and waiting for next block to get the transaction details